### PR TITLE
Casting cannot implicitly override existing methods

### DIFF
--- a/comparison/Gemfile
+++ b/comparison/Gemfile
@@ -1,1 +1,1 @@
-gem 'casting'
+gem 'casting', '1.0.1'

--- a/comparison/Gemfile.lock
+++ b/comparison/Gemfile.lock
@@ -1,9 +1,12 @@
 GEM
   specs:
-    casting (0.7.1)
+    casting (1.0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  casting
+  casting (= 1.0.1)
+
+BUNDLED WITH
+   2.3.17

--- a/comparison/models/casting_api_adapter.rb
+++ b/comparison/models/casting_api_adapter.rb
@@ -3,19 +3,17 @@ require 'casting'
 require_relative 'thing'
 
 module CastingApiAdapter
-  # Casting totally fails here.
-  #
-  # When using `Casting::Client#delegate`, we can't call super *nor* make an
-  # alias chain, so we're forced to re-define #as_json to add the path property.
-  #
-  # When using `Casting::Client#cast_as`, it doesn't overwrite existing methods
-  # at all, so our enhanced `#as_json` never gets called.
+  # Casting depends on explicit delegation or method_missing.
+  # Overriding existing methods won't hit method_missing because they are not
+  # missing, so explicit delegation must be used.
   def as_json
-    {
-      id: id,
-      name: name,
+    super.merge({
       path: name.downcase.gsub(' ','-')
-    }
+    })
+  end
+
+  def to_json
+    cast(:as_json, CastingApiAdapter).to_json
   end
 
   def slug

--- a/comparison/test/casting_test.rb
+++ b/comparison/test/casting_test.rb
@@ -5,18 +5,26 @@ require_relative 'test_helper'
 require_relative '../models/thing'
 require_relative '../models/casting_api_adapter'
 
-class Thing
+# inheriting because casting is intended to be included in the base model but
+# all tests use the same model class
+class CastingThing < Thing
   include Casting::Client
-  include Casting::MissingMethodClient
+  delegate_missing_methods
 end
 
 class TestRefiningApiAdapterInheritance < ApiAdapterTest
 
   def setup
-    @thing = Thing.new(1, 'A Thing')
-    @thing.extend(Casting::Client)
-    @thing.extend(Casting::MissingMethodClient) # not in docs, but necessary?
+    @thing = CastingThing.new(1, 'A Thing')
     @thing.cast_as(CastingApiAdapter)
+  end
+
+  def thing_as_json
+    @thing.cast(:as_json, CastingApiAdapter)
+  end
+
+  def thing_to_json
+    @thing.cast(:to_json, CastingApiAdapter)
   end
 
   run_api_tests

--- a/comparison/test/test_helper.rb
+++ b/comparison/test/test_helper.rb
@@ -9,6 +9,14 @@ class ApiAdapterTest < MiniTest::Test
     @thing = Thing.new(1, 'A Thing')
   end
 
+  def thing_as_json
+    @thing.as_json
+  end
+
+  def thing_to_json
+    @thing.to_json
+  end
+
   module Tests
     # adding a new method
     def test_api_thing_has_slug
@@ -17,12 +25,12 @@ class ApiAdapterTest < MiniTest::Test
 
     # modifying an existing method
     def test_api_thing_has_path_in_as_json
-      assert_equal 'a-thing', @thing.as_json[:path]
+      assert_equal 'a-thing', thing_as_json[:path]
     end
 
     # local rebinding
     def test_api_thing_has_path_in_to_json
-      assert_equal 'a-thing', JSON.parse(@thing.to_json)['path']
+      assert_equal 'a-thing', JSON.parse(thing_to_json)['path']
     end
 
     # maintaining some sort of class identity


### PR DESCRIPTION
The casting_test.rb seemed to assume that an object using casting could define existing
methods in attendant modules, but because it would rely on method_missing by declaring
delegate_missing_methods on the class, the existing methods would never be missing and
the module would not override anything.

The tests were altered so that differing call signatures could be reflected by the
particular style.

I know this hasn't been updated in years but I only recently found this so I'm trying to correct any misconceptions.